### PR TITLE
Allow setting CUSTOM_LOG_LEVELS for the flask app

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -32,6 +32,9 @@ This should also create the configuration file `~/.config/passari-web-ui/config.
    SECURITY_SEND_PASSWORD_RESET_EMAIL=false
    SECURITY_SEND_PASSWORD_RESET_NOTICE_EMAIL=false
 
+   # Logging configuration
+   CUSTOM_LOG_LEVELS='passlib:INFO'
+
    # URL to the MuseumPlus web UI. This is the base URL.
    # For example, the following URL should be valid:
    # {MUSEUMPLUS_UI_URL}/Object/1522

--- a/src/passari_web_ui/app.py
+++ b/src/passari_web_ui/app.py
@@ -1,3 +1,5 @@
+import logging
+
 from flask import Flask, current_app, g, redirect, request, url_for
 from flask_security import (Security, SQLAlchemySessionUserDatastore,
                             current_user)
@@ -64,6 +66,19 @@ def init_security():
     Security(current_app, user_datastore)
 
 
+def configure_custom_log_levels(log_levels):
+    if log_levels:
+        if isinstance(log_levels, str):
+            log_levels = log_levels.replace(",", " ").split()
+
+        if isinstance(log_levels, list):
+            log_levels = dict(x.split(":", 1) for x in log_levels)
+
+        for logger_name, level_name in (log_levels or {}).items():
+            logger = logging.getLogger(logger_name)
+            logger.setLevel(level_name)
+
+
 def create_app():
     """
     Create the WSGI app for passari-web-ui
@@ -74,6 +89,8 @@ def create_app():
     app.config.update(**get_flask_config())
     app.config["SQLALCHEMY_DATABASE_URI"] = get_connection_uri()
     app.config["SQLALCHEMY_TRACK_MODIFICATIONS"] = False
+
+    configure_custom_log_levels(app.config.get("CUSTOM_LOG_LEVELS"))
 
     db.init_app(app)
 

--- a/src/passari_web_ui/config.py
+++ b/src/passari_web_ui/config.py
@@ -17,6 +17,9 @@ SECURITY_SEND_PASSWORD_CHANGE_EMAIL=false
 SECURITY_SEND_PASSWORD_RESET_EMAIL=false
 SECURITY_SEND_PASSWORD_RESET_NOTICE_EMAIL=false
 
+# Logging configuration
+# CUSTOM_LOG_LEVELS='passlib:INFO'
+
 # URL to the MuseumPlus web UI. This is the base URL.
 # For example, the following URL should be valid:
 # {MUSEUMPLUS_UI_URL}/Object/1522


### PR DESCRIPTION
Add a configuration option named CUSTOM_LOG_LEVELS and use it in the Flask app initialization (create_app) to configure log level customizations for the loggers named in that option.

This allows e.g. to override the log level for passlib library, which seems to otherwise pollute the terminal with some surplus messages if general log level is set to DEBUG (10).