### PR TITLE
Fix test DB initialization

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,5 +1,5 @@
-pytest
-pytest-cov
-pytest-postgresql
-fakeredis
-lupa
+pytest~=8.3.4
+pytest-cov~=6.0.0
+pytest-postgresql~=6.1.1
+fakeredis~=2.26.1
+lupa~=2.2

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -85,7 +85,13 @@ def database(request):
 
         version = get_psql_version()
 
-        with DatabaseJanitor(user, host, port, db_name, version):
+        with DatabaseJanitor(
+            user=user,
+            host=host,
+            port=port,
+            dbname=db_name,
+            version=version
+        ):
             create_engine(
                 f"postgresql://{user}@{host}:{port}/{db_name}"
             )


### PR DESCRIPTION
The DatabaseJanitor class from pytest-postgresql only accepts keyword arguments as of v6.0.0.

Also pin the dev requirements to the latest working versions.