### PR TITLE
Fix test DB connection

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -103,6 +103,7 @@ def engine(database, monkeypatch):
     """
     Fixture for creating an empty database on each test run
     """
+    monkeypatch.setitem(WORKFLOW_CONFIG["db"], "url", "")
     monkeypatch.setitem(WORKFLOW_CONFIG["db"], "user", database.user)
     monkeypatch.setitem(
         WORKFLOW_CONFIG["db"], "password",


### PR DESCRIPTION
Since the DB name and URL are exclusive when building the connection URI in passari-workflow, clear the configured URL before creating the test database.