### PR TITLE
Enqueue objects by ids

### DIFF
--- a/src/passari_web_ui/static/js/upload_csv.js
+++ b/src/passari_web_ui/static/js/upload_csv.js
@@ -1,0 +1,18 @@
+document.getElementById('csv_file').addEventListener('change', function (event) {
+  const file = event.target.files[0];
+  if (!file) return;
+
+  const reader = new FileReader();
+  reader.onload = function (e) {
+    const content = e.target.result;
+    const lines = content.split(/[\r\n]+/).filter(line => line.trim() !== "");
+    const objectIDs = lines.join("\n");
+    document.getElementById('object_ids').value = objectIDs;
+  };
+
+  reader.onerror = function () {
+    alert("Error reading the file. Please make sure it is a valid CSV file.");
+  };
+
+  reader.readAsText(file);
+});

--- a/src/passari_web_ui/ui/forms.py
+++ b/src/passari_web_ui/ui/forms.py
@@ -9,7 +9,9 @@ from passari_workflow.db.models import MuseumObject
 
 from .validators import (
     object_ids_exist_check,
-    object_with_reason_exist_check
+    object_with_reason_exist_check,
+    object_ids_not_processed_before_check,
+    object_ids_pending_preservation_check
 )
 
 
@@ -87,6 +89,18 @@ class FreezeObjectsForm(FlaskForm):
             "one query."
         ),
         validators=[InputRequired()]
+    )
+
+
+class EnqueueObjectsByIdsForm(FlaskForm):
+    """
+    Form to enqueue objects by their IDs
+    """
+    object_ids = MultipleObjectIDField(
+        "Object IDs", validators=[
+            object_ids_pending_preservation_check,
+            object_ids_not_processed_before_check
+        ]
     )
 
 

--- a/src/passari_web_ui/ui/templates/macros.html
+++ b/src/passari_web_ui/ui/templates/macros.html
@@ -48,6 +48,7 @@
                 <textarea class="{{ form_class }}"
                           id="{{ field.id }}"
                           name="{{ field.name }}"
+                          rows="{{ kwargs.get('rows', 5) }}"
                           placeholder="{{ kwargs.get("placeholder", "") }}">
                     {%- if field.data is not none %}{{ field.data }}{% endif -%}
                 </textarea>

--- a/src/passari_web_ui/ui/templates/tabs/enqueue_objects/enqueue_objects.html
+++ b/src/passari_web_ui/ui/templates/tabs/enqueue_objects/enqueue_objects.html
@@ -17,6 +17,47 @@
                 max=available_count
             )
         }}
-        <button class="btn btn-primary" type="submit">Enqueue</button>
+        <button class="btn btn-primary" type="submit" name="submit_form" value="form1">
+            Enqueue
+        </button>
     </form>
+
+    <hr />
+
+    <div class="alert alert-secondary">
+        Enqueue new objects to the preservation workflow by providing their MuseumPlus IDs. Given objects are enqueued into the workflow.
+    </div>
+    <form method="POST" action="{{ url_for('ui.enqueue_objects') }}" autocomplete="off">
+        {{ form2.csrf_token }}
+        <div class="row">
+            <div class="col-8">
+                {{
+                    macros.render_field(
+                        form2.object_ids,
+                        placeholder="Insert each object ID into its own line",
+                        rows=10
+                    )
+                }}
+            </div>
+            <div class="col-4">
+                <label>Upload CSV File</label>
+                <input type="file" class="form-control" id="csv_file" accept=".csv"
+                    style="border:none; padding:0;">
+                <small class="form-text text-muted">
+                    Upload a CSV file to populate the object IDs (one ID per line).
+                </small>
+            </div>
+        </div>
+
+        {% if error %}
+            <div class="alert alert-danger" role="alert">
+                {{ error }}
+            </div>
+        {% endif %}
+        <button class="btn btn-primary" type="submit" name="submit_form" value="form2">
+            Enqueue
+        </button>
+    </form>
+
+    <script src="{{ url_for('static', filename='js/upload_csv.js') }}"></script>
 {% endblock content %}

--- a/src/passari_web_ui/ui/validators.py
+++ b/src/passari_web_ui/ui/validators.py
@@ -42,3 +42,45 @@ def object_with_reason_exist_check(form, field):
 
     if not result:
         raise ValidationError("No objects with this reason were found.")
+
+
+def object_ids_pending_preservation_check(form, field):
+    """
+    Check that all objects with the given IDs are pending preservation
+    """
+    if not field.data:
+        raise ValidationError("No object IDs provided")
+
+    pending_object_ids = [
+        result[0] for result in
+        db.session.query(MuseumObject.id)
+        .with_transformation(MuseumObject.filter_preservation_pending)
+        .all()
+    ]
+
+    not_pending = set(field.data) - set(pending_object_ids)
+
+    if not_pending:
+        raise ValidationError(
+            f"Following objects are not pending preservation: "
+            f"{', '.join([str(o) for o in sorted(not_pending)])}"
+        )
+
+
+def object_ids_not_processed_before_check(form, field):
+    """
+    Check that none of the given objects has been added
+    to the workflow before.
+    """
+    if not field.data:
+        raise ValidationError("No object IDs provided")
+
+    object_ids = set(field.data)
+    enqueued_object_ids = get_enqueued_object_ids()
+    already_enqueued = object_ids.intersection(enqueued_object_ids)
+
+    if already_enqueued:
+        raise ValidationError(
+            f"Objects already in the workflow and can't be enqueued: "
+            f"{', '.join(str(id) for id in sorted(already_enqueued))}"
+        )

--- a/src/passari_web_ui/ui/validators.py
+++ b/src/passari_web_ui/ui/validators.py
@@ -1,0 +1,44 @@
+from wtforms.validators import ValidationError
+
+from passari_workflow.db.models import MuseumObject
+from passari_workflow.queue.queues import get_enqueued_object_ids
+
+from ..db import db
+
+
+def object_ids_exist_check(form, field):
+    """
+    Check that all given object IDs exist
+    """
+    if not field.data:
+        raise ValidationError("No object ID was provided")
+
+    existing_object_ids = [
+        result[0] for result in
+        db.session.query(MuseumObject.id)
+        .filter(MuseumObject.id.in_(field.data))
+        .all()
+    ]
+
+    missing_object_ids = set(field.data) - set(existing_object_ids)
+
+    if missing_object_ids:
+        raise ValidationError(
+            f"Following objects don't exist: "
+            f"{', '.join([str(o) for o in sorted(missing_object_ids)])}"
+        )
+
+
+def object_with_reason_exist_check(form, field):
+    """
+    Check that at least one frozen object with the given reason exists
+    """
+    result = (
+        db.session.query(MuseumObject)
+        .filter(MuseumObject.frozen)
+        .filter(MuseumObject.freeze_reason == field.data)
+        .first()
+    )
+
+    if not result:
+        raise ValidationError("No objects with this reason were found.")

--- a/tests/ui/test_views.py
+++ b/tests/ui/test_views.py
@@ -107,7 +107,11 @@ class TestEnqueueObjects:
         assert b"<b>5</b> are available" in result.data
 
         result = client.post(
-            "/web-ui/enqueue-objects/", data={"object_count": "2"},
+            "/web-ui/enqueue-objects/",
+            data={
+                "object_count": "2",
+                "submit_form": "form1"
+            },
             follow_redirects=True
         )
         assert b"2 object(s) will be enqueued." in result.data
@@ -117,7 +121,11 @@ class TestEnqueueObjects:
         Test enqueueing two new objects when no objects are available
         """
         result = client.post(
-            "/web-ui/enqueue-objects/", data={"object_count": "2"}
+            "/web-ui/enqueue-objects/",
+            data={
+                "object_count": "2",
+                "submit_form": "form1"
+            }
         )
         assert b"There are no objects pending preservation" in result.data
 
@@ -134,9 +142,38 @@ class TestEnqueueObjects:
             )
 
         result = client.post(
-            "/web-ui/enqueue-objects/", data={"object_count": "-1"}
+            "/web-ui/enqueue-objects/",
+            data={
+                "object_count": "-1",
+                "submit_form": "form1"
+            }
         )
         assert b"Object count has to be in range 1 - 5" in result.data
+
+    def test_enqueue_objects_by_ids(self, session, client, museum_object_factory):
+        """
+        Test enqueueing three new objects by their IDs
+        """
+        for i in range(0, 5):
+            # Create five fake preservable objects
+            museum_object_factory(
+                id=i, created_date=TEST_DATE, modified_date=TEST_DATE,
+                metadata_hash="", attachment_metadata_hash=""
+            )
+
+        result = client.get("/web-ui/enqueue-objects/")
+        assert b"Enqueue objects</h1>" in result.data
+        assert b"<b>5</b> are available" in result.data
+
+        result = client.post(
+            "/web-ui/enqueue-objects/",
+            data={
+                "object_ids": "1\n2\n3", # Newline-separated IDs as a string
+                "submit_form": "form2"
+            },
+            follow_redirects=True
+        )
+        assert b"3 object(s) will be enqueued." in result.data
 
 
 @pytest.mark.usefixtures("user")


### PR DESCRIPTION
Note: This depends on https://github.com/andersinno/passari-workflow/pull/8

Add another form to the Enqueue objects view that allows
providing a list of object ids to enqueue. The provided objects
will be enqueued if they are pending preservation and haven't
been added to the workflow before.

Also add a file input field to the view that allows to provide
the list of ids by uploading a CSV file.


https://github.com/user-attachments/assets/5e04ae6f-e599-45a7-82ca-faa70331c417


Refs MPZ-11