### PR TITLE
Add dev requirements to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,11 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+dev = [
+    "fakeredis[lua]",
+    "pytest",
+    "sqlalchemy-utils",
+]
 docs = ["sphinxcontrib-apidoc"]
 
 [tool.setuptools_scm]

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,5 +1,5 @@
 pytest~=8.3.4
 pytest-cov~=6.0.0
-pytest-postgresql~=6.1.1
+sqlalchemy-utils~=0.41
 fakeredis~=2.26.1
 lupa~=2.2


### PR DESCRIPTION
List the development requirents as with package extra feature named "dev".  This allows installing them with `pip install .[dev]` or listing them in input file for pip-compile.

Also fix the requirements_dev.txt which should have sqlalchemy-utils instead of pytest-postgresql now (after commit aece752048).